### PR TITLE
fixed css problem

### DIFF
--- a/admin/css/pine-editor.css
+++ b/admin/css/pine-editor.css
@@ -59,7 +59,7 @@ body#tinymce.wp-editor h5 {
 body#tinymce.wp-editor h6 {
   font-size: 14px;
 }
-body#tinymce.wp-editor img {
+body#tinymce.wp-editor img:not(.wp-more-tag) {
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
Theme was giving all img tags in the tinymce wp-editor a height of auto this was creating a read more tag that was the height of the editor. [see screenshot](http://pasteboard.co/2cqwsRgNl.png)
